### PR TITLE
[UPDATE] deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/compute-io/tversky-index/issues"
   },
   "dependencies": {
-    "intersect": "^0.1.0",
+    "intersect": "^1.0.1",
     "validate.io-array": "^1.0.3",
     "validate.io-boolean": "^1.0.4",
     "validate.io-nonnegative": "^1.0.0",
@@ -49,14 +49,14 @@
     "validate.io-string": "^1.0.2"
   },
   "devDependencies": {
-    "chai": "1.x.x",
+    "chai": "2.x.x",
     "compute-nanmean": "^1.0.2",
     "compute-shuffle": "^1.0.0",
     "coveralls": "^2.11.1",
     "istanbul": "^0.3.0",
     "jshint": "2.x.x",
     "jshint-stylish": "^1.0.0",
-    "mocha": "1.x.x"
+    "mocha": "2.x.x"
   },
   "licenses": [
     {


### PR DESCRIPTION
- updated dependencies
- the TODO list asks to change code to use compute-intersect and compute-nanunique, do these modules exist yet?
